### PR TITLE
Signed policy symbol.

### DIFF
--- a/web/src/entities/Policy.js
+++ b/web/src/entities/Policy.js
@@ -9,7 +9,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard'
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import MaterialTooltip from "@material-ui/core/Tooltip";
 import SyncIcon from '@material-ui/icons/Sync';
-import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+import VerifiedUserIcon from '@material-ui/icons/VerifiedUser';
 import { green } from '@material-ui/core/colors';
 
 type Author = {
@@ -156,7 +156,7 @@ const PolicyItem = (props: Props) => {
             {
               policy.signed ?
                 <MaterialTooltip arrow title="Signed policy">
-                  <div className="icon-badge"><CheckCircleOutlineIcon style={{ color: green[500] }} /></div>
+                  <div className="icon-badge"><VerifiedUserIcon style={{ color: green[500] }} /></div>
                 </MaterialTooltip>
                 : null
             }

--- a/web/src/entities/Policy.js
+++ b/web/src/entities/Policy.js
@@ -11,6 +11,11 @@ import MaterialTooltip from "@material-ui/core/Tooltip";
 import SyncIcon from '@material-ui/icons/Sync';
 import VerifiedUserIcon from '@material-ui/icons/VerifiedUser';
 import { green } from '@material-ui/core/colors';
+import { makeStyles } from '@material-ui/core/styles';
+
+const signedPolicyStyle = makeStyles({
+  root: { color: green[500] }
+});
 
 type Author = {
   name: String,
@@ -51,6 +56,7 @@ const PolicyItem = (props: Props) => {
   };
 
   const policy = props.policy;
+  const classes = signedPolicyStyle();
 
   return (
     <article>
@@ -156,7 +162,7 @@ const PolicyItem = (props: Props) => {
             {
               policy.signed ?
                 <MaterialTooltip arrow title="Signed policy">
-                  <div className="icon-badge"><VerifiedUserIcon style={{ color: green[500] }} /></div>
+                  <div className="icon-badge"><VerifiedUserIcon classes={{root: classes.root}}/></div>
                 </MaterialTooltip>
                 : null
             }

--- a/web/src/entities/Policy.js
+++ b/web/src/entities/Policy.js
@@ -9,6 +9,8 @@ import { CopyToClipboard } from 'react-copy-to-clipboard'
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import MaterialTooltip from "@material-ui/core/Tooltip";
 import SyncIcon from '@material-ui/icons/Sync';
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+import { green } from '@material-ui/core/colors';
 
 type Author = {
   name: String,
@@ -30,6 +32,7 @@ export type Policy = {
   resources: Array<String>,
   mutation: Boolean,
   contextAware: Boolean,
+  signed: Boolean,
 }
 
 type Props = {
@@ -105,7 +108,7 @@ const PolicyItem = (props: Props) => {
               </a>
             : null
           }
-        </div> 
+        </div>
         <aside>
           <div>
             <span className="text-light text-tiny text-label">RESOURCES</span>
@@ -147,6 +150,13 @@ const PolicyItem = (props: Props) => {
               policy.contextAware ?
                 <MaterialTooltip arrow title="Context Aware">
                   <div className="icon-badge"><SyncIcon color="primary" /></div>
+                </MaterialTooltip>
+                : null
+            }
+            {
+              policy.signed ?
+                <MaterialTooltip arrow title="Signed policy">
+                  <div className="icon-badge"><CheckCircleOutlineIcon style={{ color: green[500] }} /></div>
                 </MaterialTooltip>
                 : null
             }


### PR DESCRIPTION
Adds a new symbol in the policy card to show when it is signed by a trusted entity. Now, when a policy is signed a green "check mark" is show in the policy card.

Related to https://github.com/kubewarden/policy-hub/issues/173

![image](https://user-images.githubusercontent.com/1514798/164225111-5c3755be-db03-4950-8aa3-51b4bbaf99ad.png)
