### PR TITLE
Check if policy is signed by Kubewarden team.

### DIFF
--- a/.github/signature_verification_config.yaml
+++ b/.github/signature_verification_config.yaml
@@ -1,0 +1,19 @@
+# Default Kubewarden verification config
+#
+# With this config, the only valid policies are those signed by Kubewarden
+# infrastructure.
+#
+# This config can be saved to its default location (for this OS) with:
+#   kwctl scaffold verification-config > /home/jvanz/.config/kubewarden/verification-config.yml
+#
+# Providing a config in the default location enables Sigstore verification.
+# See https://docs.kubewarden.io for more Sigstore verification options.
+---
+apiVersion: v1
+allOf:
+  - kind: githubAction
+    owner: kubewarden
+    repo: ~
+    annotations: ~
+anyOf: ~
+

--- a/.github/workflows/check-policy-signatures.yml
+++ b/.github/workflows/check-policy-signatures.yml
@@ -1,0 +1,26 @@
+# This action is ran  daily or manually.
+#
+# The action iterate over all the policies defined in web/policies and checks
+# if they are still signed by a trusted entity defined in the file .github/signature_verification_config.yaml.
+# If some policy is not trusted, the action fails.
+
+name: Policies signatures verification
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  check-signatures:
+    name: Check policies signatures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Install kwctl
+        uses: kubewarden/github-actions/kwctl-installer@v1
+
+      - name: Check policies signatures
+        run: scripts/verify-policies-signatures.sh

--- a/.github/workflows/update-policy.yml
+++ b/.github/workflows/update-policy.yml
@@ -6,7 +6,6 @@
 #
 # The action downloads the `hub.yml` file from the repository mentioned
 # by the input variables.
-#
 # The action then replaces the special `__TAG__` string inside of the
 # `hub.json` file with the value of the `tag` it received at invocation
 # time.
@@ -36,6 +35,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - name: install kwctl
+        uses: kubewarden/github-actions/kwctl-installer@v1
+
       - name: Check presence of hub metadata inside of remote repo
         run: |
           HTTP_CODE=$(curl --head -s -o /dev/null -w "%{http_code}" \
@@ -47,12 +49,17 @@ jobs:
           curl -L https://github.com/mikefarah/yq/releases/download/v4.7.0/yq_linux_amd64 -o yq
           chmod 755 yq
 
-      - name: fetch policy definition
+      - name: fetch policy definition and check if it's trusted
         run: |
           export OUTPUT=$(echo ${{ github.event.inputs.repository }} | sed -e "s|/|:|")
           curl https://raw.githubusercontent.com/${{ github.event.inputs.repository }}/${{ github.event.inputs.tag }}/hub.yml | \
             sed -e "s|__TAG__|${{ github.event.inputs.tag }}|g" | \
-            ./yq eval -j > web/policies/${OUTPUT}.json
+            ./yq eval -j > web/policies/${OUTPUT}.json && \
+            REGISTRY=$(jq -r ".download.registry" web/policies/${OUTPUT}.json) && \
+            kwctl verify --verification-config-path .github/signature_verification_config.yaml  ${REGISTRY} && \
+            jq ".signed |= true" web/policies/${OUTPUT}.json > /tmp/policy.json && \
+            mv /tmp/policy.json web/policies/${OUTPUT}.json && \
+            jq "" web/policies/${OUTPUT}.json
 
       # This is needed otherwise the PR will include the yq binary too
       - name: remove yq

--- a/scripts/verify-policies-signatures.sh
+++ b/scripts/verify-policies-signatures.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+POLICIES=`ls web/policies/`
+UNTRUSTED_POLICIES=()
+for policy in $POLICIES
+do
+	REGISTRY=$(jq -r ".download.registry" web/policies/${policy})
+	kwctl verify --verification-config-path .github/signature_verification_config.yaml ${REGISTRY} 2> /dev/null
+	if [[ $? -ne 0 ]]; then
+		UNTRUSTED_POLICIES+=$REGISTRY
+	fi
+done
+if [[ ${#UNTRUSTED_POLICIES[@]} -gt 0 ]]; then
+	echo "There are untrusted policies in the policy hub. Which are:"
+	for policy in ${UNTRUSTED_POLICIES[@]}
+	do
+		echo -e "\t$policy"
+	done
+	exit 1
+fi
+echo "All policies are signed and trusted."
+exit 0


### PR DESCRIPTION
Updates the update-policy.yml workflow to check if the policy under update is signed by the Kubewarden organization. The workflow uses kwctl to generate the config file with the signature constraints and to verify the policy OCI artefact.

Depends on https://github.com/kubewarden/github-actions/pull/26